### PR TITLE
Fix processing of single vacancy (fixes the actual issue of #1)

### DIFF
--- a/src/Traits/Reader.php
+++ b/src/Traits/Reader.php
@@ -24,8 +24,13 @@ trait Reader
 
             $objXml  = simplexml_load_file($this->strWsUrl, 'SimpleXMLElement', LIBXML_NOCDATA);
             $strJson = json_encode($objXml);
+            $arrPositions = json_decode($strJson, true)['position'];
+            // Only one position
+            if (is_array($arrPositions) && !isset($arrPositions[0])) {
+                $arrPositions = [$arrPositions];
+            }
 
-            return json_decode($strJson, true)['position'];
+            return $arrPositions;
         });
     }
 


### PR DESCRIPTION
If there is only one position in the XML, the array returned by `Reader#getXml()` will be lacking the numeric-key level and instead be the single position itself, leading to garbage output further along. The problem originates with the way SimpleXMLElement represents this case and it being JSON-encoded/decoded.
See also here:
https://stackoverflow.com/questions/23766159/php-simplexml-arrays-generated-differently-for-single-child-and-multiple-child
It would probably be better to not use an array or to not create it that way, but as the entire rest of the bundle relies on it being an array, it's better to just catch this special case.

To reproduce the issue, create a file like this and use the path to it as the webservice URL:
```
<workzag-jobs>
    <position>
        <id>123</id>
        <office>Musterstadt</office>
        <department>IT</department>
        <recruitingCategory>Example</recruitingCategory>
        <name>Developer (m/w/d)</name>
        <jobDescriptions>
            <jobDescription>
                <name>Something!</name>
                <value>Foo.</value>
            </jobDescription>
            <jobDescription>
                <name>Else.</name>
                <value>Bar.</value>
            </jobDescription>
        </jobDescriptions>
        <employmentType>permanent</employmentType>
        <seniority>entry-level</seniority>
        <schedule>full-time</schedule>
        <yearsOfExperience>1-2</yearsOfExperience>
        <occupation>general_and_other_it_software</occupation>
        <occupationCategory>it_software</occupationCategory>
        <createdAt>2021-10-12T09:02:11+00:00</createdAt>
    </position>
</workzag-jobs>
```